### PR TITLE
Handle rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ If you want to contribute please do get in touch.
 
 ## Installing
 
-```
-sh
+```sh
 pip install openglass
 
 ```

--- a/openglass/__init__.py
+++ b/openglass/__init__.py
@@ -169,7 +169,7 @@ def main(cwd=None):
 
         t = Twitter(utility.get_setting('twitter_apis'))
         if search:
-            res = t.search(q_search)['statuses']
+            res = t.search(q_search)
             if csv:
                 save_as_csv(res, "{}-{}.csv".format(q_search, epoch_time))
             else:

--- a/openglass/__init__.py
+++ b/openglass/__init__.py
@@ -183,7 +183,7 @@ def main(cwd=None):
                 print(json.dumps(res, indent=4, sort_keys=True))
             sys.exit()
         elif profile:
-            res = t.get_statuses(q_profile)
+            res = t.get_profile(q_profile)
             if csv:
                 save_as_csv(res, "{}-{}.csv".format(q_profile, epoch_time))
             else:

--- a/openglass/twitter.py
+++ b/openglass/twitter.py
@@ -6,76 +6,61 @@ class Twitter:
 
     def __init__(self, twitter_apis):
         self.twitter_apis = twitter_apis
-        self.api = self.__authenticate(self.twitter_apis[0])
-        self.api_index = 0
+        if len(self.twitter_apis) == 0:
+            exit('Provide at least one Twitter API key')
+        for twitter_api in self.twitter_apis:
+            twitter_api['expired_at'] = {}
+        self.api_in_use = self.twitter_apis[0]
+        self.api = self.__authenticate(self.api_in_use)
+        self.current_url = ''
 
     def get_followers(self, user):
-        followers = []
-
-        try:
-            followers = self.api.followers(user)
-        except tweepy.RateLimitError as e:
-            self.__handle_time_limit()
-        except Exception as e:
-            return e
-
-        return followers
+        self.current_url = '/followers/list'
+        return [ follower._json for follower in self.__limit_handled(tweepy.Cursor(self.api.followers, id=user).items()) ]
 
     def get_profile(self, user):
-        profile = []
-
-        try:
-            profile = self.api.get_user(user_id)
-        except tweepy.RateLimitError as e:
-            self.__handle_time_limit()
-        except Exception as e:
-            return e
-
-        return profile
+        self.current_url = '/users/show'
+        return self.api.get_user(id=user)._json
 
     def get_statuses(self, user):
-        tweets = []
-        try:
-            tweets = self.api.user_timeline(user, count=200)
-        except tweepy.RateLimitError as e:
-            self.__handle_time_limit()
-        except Exception as e:
-            return e
-
-        return tweets
+        self.current_url = '/statuses/user_timeline'
+        return [ tweet._json for tweet in self.__limit_handled(tweepy.Cursor(self.api.user_timeline, id=user).items()) ]
 
     def search(self, q):
-        tweets = []
-
-        try:
-            tweets = self.api.search(q, count=500)
-        except tweepy.RateLimitError as e:
-            self.__handle_time_limit()
-        except Exception as e:
-            return e
-
-        return tweets
+        self.current_url = '/search/tweets'
+        return [ tweet._json for tweet in self.__limit_handled(tweepy.Cursor(self.api.search, q=q).items()) ]
 
     def __authenticate(self, credentials):
-            auth = tweepy.OAuthHandler(credentials['CONSUMER_KEY'], credentials['CONSUMER_SECRET'])
-            auth.set_access_token(credentials['ACCESS_KEY'], credentials['ACCESS_SECRET'])
-            api = tweepy.API(auth, parser=tweepy.parsers.JSONParser())
-            return api
+        auth = tweepy.OAuthHandler(credentials['CONSUMER_KEY'], credentials['CONSUMER_SECRET'])
+        auth.set_access_token(credentials['ACCESS_KEY'], credentials['ACCESS_SECRET'])
+        api = tweepy.API(auth)
+        return api
 
     def __limit_handled(self, cursor):
         while True:
             try:
                 yield cursor.next()
+            except StopIteration:
+                return None
             except tweepy.RateLimitError:
                 self.__handle_time_limit()
+            except tweepy.error.TweepError as e:
+                if 'status code = 429' in str(e):
+                    self.__handle_time_limit()
+                else:
+                    raise e
 
     def __handle_time_limit(self):
-        if self.twitter_apis.len() > 1:
-            if self.api_index == (self.twitter_apis.len() - 1):
-                window = 15 / self.twitter_apis.len()
-                time.sleep(window * 60)
-            else:
-                self.api_index += 1
-                self.api = self.__authenticate(self.twitter_apis[self.api_index])
+        now = time.time()
+        self.api_in_use['expired_at'][self.current_url] = now
+
+        valid_apis = [ twitter_api for twitter_api in self.twitter_apis if self.current_url not in twitter_api['expired_at'] or now - twitter_api['expired_at'][self.current_url] >= 15 * 60 ]
+        if len(valid_apis) > 0:
+            self.api_in_use = valid_apis[0]
+            self.api = self.__authenticate(self.api_in_use)
         else:
-            time.sleep(15 * 60)
+            self.twitter_apis.sort(reverse=False, key=lambda api: api['expired_at'][self.current_url])
+            self.api_in_use = self.twitter_apis[0]
+            time_expired = now - self.api_in_use['expired_at'][self.current_url]
+            self.api = self.__authenticate(self.api_in_use)
+            time.sleep(15 * 60 - time_expired)


### PR DESCRIPTION
Now each API Key has a field called "expired_at" where the time expiration of each individual path is stored.
This means that now, a key might be expired for the `--timeline` functionality but not for the `--search` functionality.
If all keys are expired, the one that has been expired the longest is used.